### PR TITLE
FEAT: mdbook documentation for foss student club handbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+      - feat/mdbook
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # To push a branch 
+      pages: write  # To push to a GitHub Pages site
+      id-token: write # To update the deployment status
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install latest mdbook
+        run: |
+          tag=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
+          url="https://github.com/rust-lang/mdbook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+          mkdir mdbook
+          curl -sSL $url | tar -xz --directory=./mdbook
+          echo `pwd`/mdbook >> $GITHUB_PATH
+      - name: Build Book
+        run: |
+          # This assumes your book is in the root of your repository.
+          # Just add a `cd` here if you need to change to another directory.
+          cd foss-club-handbook
+          mdbook build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: 'book'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *~
+foss-club-handbook/book

--- a/foss-club-handbook/book.toml
+++ b/foss-club-handbook/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Poruri Sai Rahul"]
+language = "en"
+multilingual = false
+src = "src"
+title = "FOSS Student Club Handbook"

--- a/foss-club-handbook/src/SUMMARY.md
+++ b/foss-club-handbook/src/SUMMARY.md
@@ -1,0 +1,8 @@
+# Summary
+
+- [Qualifications for starting a club](./qualifications.md)
+- [Organizational structure of the club](./structure.md)
+- [Activities](./activities/README.md)
+    - [Awareness sessions](./activities/awareness.md)
+    - [Action sessions](./activities/action.md)
+    - [Tech aid clinics](./activities/techaid.md)

--- a/foss-club-handbook/src/activities/action.md
+++ b/foss-club-handbook/src/activities/action.md
@@ -1,0 +1,1 @@
+# Action sessions

--- a/foss-club-handbook/src/activities/awareness.md
+++ b/foss-club-handbook/src/activities/awareness.md
@@ -1,0 +1,1 @@
+# Awareness sessions

--- a/foss-club-handbook/src/activities/techaid.md
+++ b/foss-club-handbook/src/activities/techaid.md
@@ -1,0 +1,1 @@
+# Tech aid clinics

--- a/foss-club-handbook/src/chapter_1.md
+++ b/foss-club-handbook/src/chapter_1.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/foss-club-handbook/src/qualifications.md
+++ b/foss-club-handbook/src/qualifications.md
@@ -1,0 +1,3 @@
+# Qualifications
+
+

--- a/foss-club-handbook/src/structure.md
+++ b/foss-club-handbook/src/structure.md
@@ -1,0 +1,1 @@
+# Organizational structure of the club


### PR DESCRIPTION
fixes #5 

This PR setups up the scaffolding for mdbook docs for the FOSS Student Club Handbook. The handbook is meant for use by FOSS United recognized student clubs and by any student club that is interested in using the handbook to promote FOSS within their college.

The mdbook doesn't contain any content at the moment but the scaffolding lays out the overall structure, and sets up GitHub actions workflow to push changes to github pages automatically. Please note that the settings for the repository were updated - in "Pages", "Deploy from Branch" was changed to "Deploy via GitHub Actions"

Once setup, the mdbook will contain all of the necessary information about how FOSS United determines how Student clubs are officially recognized, the organizational structure of the club that we recommend, the various activities that we can suggest, and more. A significant number of references will be provided to ensure that each college is able to find at least a few that are useful in their context.